### PR TITLE
Add PyPI requirements at setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.4.3"
+  - "3.5.1"
 env:
   - DJANGO=1.9.5
 install:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django == 1.9.5
--e git://github.com/fidals/refarm-seo.git#egg=refarm-seo
+-e git+https://github.com/fidals/refarm-seo.git#egg=refarm-seo
+-e .

--- a/setup.py
+++ b/setup.py
@@ -32,4 +32,8 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
+    install_requires=[
+        'Django == 1.9.5',
+        'refarm-seo',
+    ],
 )


### PR DESCRIPTION
Add PyPI requirements at setup.py. Add our nonPyPI repos in requirements.txt
Used price from this arcicle: https://caremad.io/2013/07/setup-vs-requirement/

resolve #8 